### PR TITLE
Fixed analizing via .sb3  upload

### DIFF
--- a/app/certificate/output.aux
+++ b/app/certificate/output.aux
@@ -1,2 +1,0 @@
-\relax 
-\gdef \@abspage@last{1}

--- a/app/views.py
+++ b/app/views.py
@@ -519,6 +519,7 @@ def check_version(filename):
     Check the version of the project and return it
     """
 
+    filename = filename.decode('utf-8')
     extension = filename.split('.')[-1]
     if extension == 'sb2':
         version = '2.0'

--- a/app/views.py
+++ b/app/views.py
@@ -236,7 +236,7 @@ def _make_analysis_by_upload(request):
                 destination.write(chunk)
 
         try:
-            dict_drscratch_analysis = analyze_project(request, file_name, zip_filename, ext_type_project=None)
+            dict_drscratch_analysis = analyze_project(request, file_name, filename_obj, ext_type_project=None)
         except Exception:
             traceback.print_exc()
             filename_obj.method = 'project/error'


### PR DESCRIPTION
I have modified the third analyze_project argument, this is because the old value (zip_filename) was an bytes type, and the function needed a object data type, because used attributes. So i replaced the zip_filename argument for filename_obj